### PR TITLE
Add support for ssd1315 displays

### DIFF
--- a/display_driver.c
+++ b/display_driver.c
@@ -67,6 +67,8 @@ Context *display_create_port(GlobalContext *global, term opts)
         ctx = ili948x_display_create_port(global, opts);
     } else if (!strcmp(compat_string, "solomon-systech,ssd1306")) {
         ctx = ssd1306_display_create_port(global, opts);
+    } else if (!strcmp(compat_string, "solomon-systech,ssd1315")) {
+        ctx = ssd1306_display_create_port(global, opts);
     } else if (!strcmp(compat_string, "sino-wealth,sh1106")) {
         ctx = ssd1306_display_create_port(global, opts);
     } else if (!strcmp(compat_string, "sitronix,st7789")


### PR DESCRIPTION
This PR adds supporf for ssd1315 displays. ssd1315 is mostly compatible with ssd1306 drivers, but it has some small differences, such as requiring a special initialization sequence and needing an explicit column address reset when updating.

I also increased the timeout window from 10 to 100, to fix this error i was getting:
`E (1225) SSD1306: I2C write failed for display update: 0x107` [(a timeout)](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/error-codes.html)

The initialization sequence is based on the one used in [u8g2](https://github.com/olikraus/u8g2/blob/dbd338af5d57b219e48ea1ffdb97c4153668676c/csrc/u8x8_d_ssd1315_128x64_noname.c).

Tested on an ESP32.